### PR TITLE
finalize sidebar

### DIFF
--- a/thi-app/components/Sidebar.tsx
+++ b/thi-app/components/Sidebar.tsx
@@ -140,24 +140,32 @@ const Sidebar = ({ animatedValue }: { animatedValue: SharedValue<number> }) => {
                 />
 
                 {/* Schedule */}
-                <SidebarTab
+                {/* <SidebarTab
                   iconSet={MaterialCommunityIcons}
                   iconName="calendar-multiple"
                   label="Schedule"
-                />
+                /> */}
 
                 {/* Games */}
-                <SidebarTab
+                {/* <SidebarTab
                   iconSet={MaterialCommunityIcons}
                   iconName="gamepad-square-outline"
                   label="Games"
-                />
+                /> */}
 
                 {/* Timer */}
                 <SidebarTab iconSet={MaterialCommunityIcons} iconName="timer-sand" label="Timer" />
 
                 {/* Settings */}
-                <SidebarTab iconSet={FontAwesome} iconName="gear" label="Settings" />
+                {/* <SidebarTab iconSet={FontAwesome} iconName="gear" label="Settings" /> */}
+
+                {/* Padding */}
+                <View className="flex-col items-start justify-between"
+                  style={{
+                    height: Dimensions.get("window").height * 0.3,
+                    width: openSidebarWidth,
+                  }}/>
+
               </View>
             </Animated.View>
           )}

--- a/thi-app/components/Sidebar.tsx
+++ b/thi-app/components/Sidebar.tsx
@@ -162,7 +162,7 @@ const Sidebar = ({ animatedValue }: { animatedValue: SharedValue<number> }) => {
                 {/* Padding */}
                 <View className="flex-col items-start justify-between"
                   style={{
-                    height: Dimensions.get("window").height * 0.3,
+                    height: Dimensions.get("window").height * 0.2,
                     width: openSidebarWidth,
                   }}/>
 

--- a/thi-app/components/SidebarTab.tsx
+++ b/thi-app/components/SidebarTab.tsx
@@ -57,7 +57,7 @@ const SidebarTab = ({
   const directory = "/" + tabName;
   const isActive = currentScreen.includes(tabName);
   // Sidebar tab details
-  const tabHeight = Dimensions.get("window").height * 0.08;
+  const tabHeight = Dimensions.get("window").height * 0.11;
   const tabIconTextColor = useActiveColor && isActive ? activeIconTextColor : defaultIconTextColor;
   const tabButtonColor = useActiveColor && isActive ? activeTabColor : defaultTabColor;
 


### PR DESCRIPTION
removed currently unused tabs and resized sidebar tabs to fit the space

icon sizing error on tablets from previous sidebar doesn't seem to be present anymore
![image](https://github.com/user-attachments/assets/0e167126-1933-4500-832a-280ccb9bcf83)
